### PR TITLE
feat: scaffold Vite React app for UI and add GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -1,0 +1,44 @@
+name: Deploy UI to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths: [ui/**]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+      - run: npm ci
+        working-directory: ui
+      - run: npm run build
+        working-directory: ui
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ui/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>KCD Toronto 2026 - AI Ticketing Pipeline</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/ui/kcd-toronto.jsx
+++ b/ui/kcd-toronto.jsx
@@ -1,0 +1,858 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+
+const COLORS = {
+  navy: "#1a2744",
+  navyLight: "#243352",
+  teal: "#2dd4a8",
+  tealDark: "#1fa882",
+  red: "#e63946",
+  redDark: "#c1121f",
+  gold: "#f4a261",
+  white: "#f8f9fa",
+  gray: "#94a3b8",
+  grayDark: "#475569",
+  bg: "#0f1729",
+  card: "#1e293b",
+  cardHover: "#263548",
+};
+
+const fonts = `
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&family=Outfit:wght@300;400;500;600;700;800;900&display=swap');
+`;
+
+// ─── Utility: Intersection Observer Hook ───
+function useInView(threshold = 0.2) {
+  const ref = useRef(null);
+  const [inView, setInView] = useState(false);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const obs = new IntersectionObserver(
+      ([e]) => { if (e.isIntersecting) setInView(true); },
+      { threshold }
+    );
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, [threshold]);
+  return [ref, inView];
+}
+
+// ─── Animated Counter ───
+function Counter({ end, duration = 1500, suffix = "", prefix = "", inView }) {
+  const [val, setVal] = useState(0);
+  useEffect(() => {
+    if (!inView) return;
+    let start = 0;
+    const step = end / (duration / 16);
+    const id = setInterval(() => {
+      start += step;
+      if (start >= end) { setVal(end); clearInterval(id); }
+      else setVal(Math.floor(start));
+    }, 16);
+    return () => clearInterval(id);
+  }, [inView, end, duration]);
+  return <span>{prefix}{val}{suffix}</span>;
+}
+
+// ─── Section Wrapper ───
+function Section({ id, children, dark = true, style = {} }) {
+  const [ref, inView] = useInView(0.1);
+  return (
+    <section
+      ref={ref}
+      id={id}
+      style={{
+        minHeight: "100vh",
+        padding: "100px 24px",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        background: dark ? COLORS.bg : COLORS.navy,
+        position: "relative",
+        opacity: inView ? 1 : 0,
+        transform: inView ? "translateY(0)" : "translateY(40px)",
+        transition: "opacity 0.8s ease, transform 0.8s ease",
+        ...style,
+      }}
+    >
+      {children}
+    </section>
+  );
+}
+
+// ─── Navigation ───
+function Nav({ active }) {
+  const items = [
+    { id: "hero", label: "Home" },
+    { id: "problem", label: "Problem" },
+    { id: "vsm", label: "Value Stream" },
+    { id: "architecture", label: "Architecture" },
+    { id: "simulator", label: "Simulator" },
+    { id: "metrics", label: "Metrics" },
+  ];
+  return (
+    <nav style={{
+      position: "fixed", top: 0, left: 0, right: 0, zIndex: 100,
+      background: "rgba(15,23,41,0.85)", backdropFilter: "blur(16px)",
+      borderBottom: `1px solid ${COLORS.navyLight}`,
+      display: "flex", justifyContent: "center", gap: 8, padding: "12px 16px",
+    }}>
+      <span style={{
+        fontFamily: "'JetBrains Mono'", fontWeight: 700, color: COLORS.teal,
+        fontSize: 14, marginRight: "auto", paddingLeft: 8,
+        letterSpacing: "0.05em",
+      }}>KCD Toronto 2026</span>
+      {items.map(it => (
+        <a key={it.id} href={`#${it.id}`} style={{
+          color: active === it.id ? COLORS.teal : COLORS.gray,
+          textDecoration: "none", fontSize: 13, fontFamily: "'Outfit'",
+          fontWeight: active === it.id ? 600 : 400,
+          padding: "4px 12px", borderRadius: 6,
+          background: active === it.id ? "rgba(45,212,168,0.1)" : "transparent",
+          transition: "all 0.2s",
+        }}>{it.label}</a>
+      ))}
+    </nav>
+  );
+}
+
+// ─── Hero ───
+function Hero() {
+  const [loaded, setLoaded] = useState(false);
+  useEffect(() => { setTimeout(() => setLoaded(true), 100); }, []);
+  return (
+    <section id="hero" style={{
+      minHeight: "100vh", display: "flex", flexDirection: "column",
+      alignItems: "center", justifyContent: "center", textAlign: "center",
+      background: `radial-gradient(ellipse at 50% 30%, ${COLORS.navyLight} 0%, ${COLORS.bg} 70%)`,
+      padding: "60px 24px", position: "relative", overflow: "hidden",
+    }}>
+      {/* Grid background */}
+      <div style={{
+        position: "absolute", inset: 0, opacity: 0.06,
+        backgroundImage: `linear-gradient(${COLORS.teal} 1px, transparent 1px), linear-gradient(90deg, ${COLORS.teal} 1px, transparent 1px)`,
+        backgroundSize: "60px 60px",
+      }} />
+      {/* Glow */}
+      <div style={{
+        position: "absolute", top: "20%", left: "50%", transform: "translate(-50%,-50%)",
+        width: 600, height: 600, borderRadius: "50%",
+        background: `radial-gradient(circle, rgba(45,212,168,0.12) 0%, transparent 70%)`,
+        filter: "blur(60px)",
+      }} />
+      <div style={{
+        position: "relative", zIndex: 1,
+        opacity: loaded ? 1 : 0, transform: loaded ? "translateY(0)" : "translateY(30px)",
+        transition: "all 1s ease 0.2s",
+      }}>
+        <div style={{
+          fontFamily: "'JetBrains Mono'", fontSize: 13, color: COLORS.teal,
+          letterSpacing: "0.2em", textTransform: "uppercase", marginBottom: 24,
+          background: "rgba(45,212,168,0.1)", display: "inline-block",
+          padding: "6px 20px", borderRadius: 20, border: `1px solid rgba(45,212,168,0.2)`,
+        }}>KCD Toronto 2026</div>
+        <h1 style={{
+          fontFamily: "'Outfit'", fontWeight: 900, fontSize: "clamp(42px, 7vw, 86px)",
+          color: COLORS.white, lineHeight: 1.05, margin: "16px 0",
+          maxWidth: 800,
+        }}>
+          Reducing Cycle Time{" "}
+          <span style={{ color: COLORS.teal }}>10x</span>
+        </h1>
+        <p style={{
+          fontFamily: "'Outfit'", fontWeight: 300, fontSize: "clamp(18px, 2.5vw, 26px)",
+          color: COLORS.teal, margin: "12px 0 32px", maxWidth: 600,
+        }}>
+          Building an Intelligent Ticket Pipeline on Kubernetes
+        </p>
+        <div style={{
+          fontFamily: "'Outfit'", fontSize: 15, color: COLORS.gray, marginBottom: 40,
+        }}>
+          Gonzalo Vazquez &middot; Director, Cloud Engineering &middot; Royal Bank of Canada
+        </div>
+        <a href="#problem" style={{
+          display: "inline-flex", alignItems: "center", gap: 8,
+          background: COLORS.teal, color: COLORS.navy, fontFamily: "'Outfit'",
+          fontWeight: 600, fontSize: 15, padding: "14px 32px", borderRadius: 8,
+          textDecoration: "none", transition: "transform 0.2s, box-shadow 0.2s",
+          boxShadow: "0 4px 24px rgba(45,212,168,0.3)",
+        }}>
+          Explore the Pipeline &#8595;
+        </a>
+      </div>
+    </section>
+  );
+}
+
+// ─── Problem Statement ───
+function ProblemSection() {
+  const [ref, inView] = useInView(0.2);
+  const wastes = [
+    { name: "Overproduction", icon: "📦", desc: "Creating tickets nobody asked for" },
+    { name: "Waiting Time", icon: "⏳", desc: "Queuing for human review" },
+    { name: "Superfluous Movement", icon: "🔄", desc: "Context switching between tools" },
+    { name: "Transport", icon: "🚚", desc: "Moving data across systems manually" },
+    { name: "Overprocessing", icon: "⚙️", desc: "Redundant analysis steps" },
+    { name: "Inventory/Stock", icon: "📋", desc: "Backlog of unprocessed requests" },
+    { name: "Defects & Rework", icon: "🔁", desc: "~30% ticket reopen rate" },
+  ];
+  return (
+    <Section id="problem">
+      <div ref={ref} style={{ maxWidth: 1000, width: "100%" }}>
+        <div style={{
+          fontFamily: "'JetBrains Mono'", fontSize: 12, color: COLORS.teal,
+          letterSpacing: "0.15em", textTransform: "uppercase", marginBottom: 12,
+        }}>The Problem</div>
+        <h2 style={{
+          fontFamily: "'Outfit'", fontWeight: 800, fontSize: "clamp(28px,4vw,48px)",
+          color: COLORS.white, margin: "0 0 12px",
+        }}>
+          AI optimizes processes...{" "}
+          <span style={{ color: COLORS.gray, fontWeight: 300 }}>
+            if we know how to measure them.
+          </span>
+        </h2>
+        <p style={{
+          fontFamily: "'Outfit'", fontSize: 17, color: COLORS.gray, maxWidth: 650,
+          lineHeight: 1.6, marginBottom: 48,
+        }}>
+          A process is standardized and repeatable. Value is added when the output
+          is greater than the input. The Japanese concept of <em>Muda</em> teaches
+          us to eliminate waste to maximize value.
+        </p>
+        <h3 style={{
+          fontFamily: "'Outfit'", fontWeight: 600, fontSize: 20, color: COLORS.white,
+          marginBottom: 24,
+        }}>Seven Types of Waste (Muda)</h3>
+        <div style={{
+          display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
+          gap: 12,
+        }}>
+          {wastes.map((w, i) => (
+            <div key={w.name} style={{
+              background: COLORS.card, borderRadius: 10, padding: "18px 16px",
+              border: `1px solid ${COLORS.navyLight}`,
+              opacity: inView ? 1 : 0,
+              transform: inView ? "translateY(0)" : "translateY(20px)",
+              transition: `all 0.5s ease ${i * 0.07}s`,
+            }}>
+              <div style={{ fontSize: 24, marginBottom: 6 }}>{w.icon}</div>
+              <div style={{
+                fontFamily: "'Outfit'", fontWeight: 600, fontSize: 14,
+                color: COLORS.white, marginBottom: 4,
+              }}>{w.name}</div>
+              <div style={{
+                fontFamily: "'Outfit'", fontSize: 12, color: COLORS.gray, lineHeight: 1.4,
+              }}>{w.desc}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </Section>
+  );
+}
+
+// ─── Value Stream Map ───
+function VSMSection() {
+  const [ref, inView] = useInView(0.15);
+  const [showFuture, setShowFuture] = useState(false);
+
+  const currentSteps = [
+    { name: "Issue Created", ct: "2 min", wait: null, color: COLORS.red },
+    { name: "Queue for Review", ct: "N/A", wait: "15 min", color: COLORS.red },
+    { name: "Manual Analysis", ct: "12 min", wait: null, color: COLORS.red },
+    { name: "Clarification", ct: "5 min", wait: "8 min", color: COLORS.red },
+    { name: "Write Requirements", ct: "10 min", wait: null, color: COLORS.red },
+    { name: "Create Jira Ticket", ct: "5 min", wait: null, color: COLORS.red },
+  ];
+
+  const futureSteps = [
+    { name: "Issue Created", ct: "1 min", wait: null, color: COLORS.teal, auto: false },
+    { name: "Webhook Trigger", ct: "< 1 sec", wait: null, color: COLORS.teal, auto: true },
+    { name: "AI Analysis (LLM + MCP)", ct: "2 min", wait: null, color: COLORS.teal, auto: true },
+    { name: "Auto-Create Jira", ct: "30 sec", wait: null, color: COLORS.teal, auto: true },
+    { name: "Human Review", ct: "1 min", wait: null, color: COLORS.teal, auto: false },
+  ];
+
+  const steps = showFuture ? futureSteps : currentSteps;
+  const title = showFuture ? "Future State" : "Current State";
+  const leadTime = showFuture ? "< 5 minutes" : "45+ minutes";
+
+  return (
+    <Section id="vsm" dark={false}>
+      <div ref={ref} style={{ maxWidth: 1100, width: "100%" }}>
+        <div style={{
+          fontFamily: "'JetBrains Mono'", fontSize: 12, color: COLORS.teal,
+          letterSpacing: "0.15em", textTransform: "uppercase", marginBottom: 12,
+        }}>Value Stream Map</div>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: 16, marginBottom: 32 }}>
+          <div>
+            <h2 style={{
+              fontFamily: "'Outfit'", fontWeight: 800, fontSize: "clamp(26px,3.5vw,42px)",
+              color: COLORS.white, margin: 0,
+            }}>{title} Value Stream Map</h2>
+            <p style={{
+              fontFamily: "'Outfit'", fontSize: 15, color: COLORS.gray, margin: "4px 0 0",
+            }}>
+              {showFuture ? "Automated Pipeline" : "Manual Intake Process"} &mdash; Lead Time: {" "}
+              <span style={{ color: showFuture ? COLORS.teal : COLORS.red, fontWeight: 600 }}>{leadTime}</span>
+            </p>
+          </div>
+          <button onClick={() => setShowFuture(!showFuture)} style={{
+            background: showFuture ? COLORS.red : COLORS.teal,
+            color: showFuture ? COLORS.white : COLORS.navy,
+            fontFamily: "'Outfit'", fontWeight: 600, fontSize: 14,
+            padding: "10px 24px", borderRadius: 8, border: "none", cursor: "pointer",
+            transition: "all 0.3s",
+          }}>
+            {showFuture ? "Show Current State" : "Show Future State"}
+          </button>
+        </div>
+
+        {/* Process Steps */}
+        <div style={{
+          display: "flex", gap: 8, overflowX: "auto", paddingBottom: 16,
+        }}>
+          {steps.map((s, i) => (
+            <div key={`${showFuture}-${i}`} style={{
+              flex: "1 0 140px", minWidth: 140,
+              background: COLORS.card, borderRadius: 10,
+              border: `2px solid ${s.color}`,
+              padding: 16, textAlign: "center",
+              opacity: inView ? 1 : 0,
+              transform: inView ? "translateY(0)" : "translateY(20px)",
+              transition: `all 0.4s ease ${i * 0.08}s`,
+            }}>
+              <div style={{
+                fontFamily: "'Outfit'", fontWeight: 600, fontSize: 14,
+                color: COLORS.white, marginBottom: 8, minHeight: 36,
+              }}>{s.name}</div>
+              <div style={{
+                fontFamily: "'JetBrains Mono'", fontSize: 12, color: s.color,
+              }}>C/T: {s.ct}</div>
+              {s.wait && (
+                <div style={{
+                  fontFamily: "'JetBrains Mono'", fontSize: 12, color: COLORS.gold,
+                  marginTop: 4,
+                }}>Wait: {s.wait}</div>
+              )}
+              {s.auto !== undefined && (
+                <div style={{
+                  marginTop: 8, fontSize: 10, fontFamily: "'JetBrains Mono'",
+                  color: s.auto ? COLORS.teal : COLORS.gray,
+                  background: s.auto ? "rgba(45,212,168,0.15)" : "rgba(148,163,184,0.15)",
+                  padding: "3px 10px", borderRadius: 10, display: "inline-block",
+                  fontWeight: 600,
+                }}>{s.auto ? "AUTOMATED" : "MANUAL"}</div>
+              )}
+              {/* Arrow */}
+              {i < steps.length - 1 && (
+                <div style={{
+                  position: "absolute", right: -16, top: "50%", color: COLORS.gray,
+                  fontSize: 18,
+                }}>&#8594;</div>
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* Timeline bar */}
+        <div style={{
+          display: "flex", marginTop: 16, height: 28, borderRadius: 6, overflow: "hidden",
+          background: COLORS.card,
+        }}>
+          {steps.map((s, i) => {
+            const widths = showFuture ? [20, 2, 45, 13, 20] : [4, 28, 22, 24, 18, 9];
+            return (
+              <div key={i} style={{
+                flex: `${widths[i]} 0 0`,
+                background: s.wait ? COLORS.red + "55" : s.color + "44",
+                display: "flex", alignItems: "center", justifyContent: "center",
+                fontFamily: "'JetBrains Mono'", fontSize: 10, color: COLORS.white,
+                borderRight: i < steps.length - 1 ? `1px solid ${COLORS.bg}` : "none",
+                transition: "all 0.5s ease",
+              }}>
+                {s.ct}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Metrics comparison */}
+        <div style={{
+          display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+          gap: 12, marginTop: 32,
+        }}>
+          {[
+            { label: "Process Efficiency", before: "56%", after: "95%+" },
+            { label: "Quality Issues", before: "~30% rework", after: "< 5% rework" },
+            { label: "Bottleneck", before: "Human queue", after: "None (event-driven)" },
+          ].map((m, i) => (
+            <div key={m.label} style={{
+              background: COLORS.card, borderRadius: 8, padding: 16,
+              border: `1px solid ${COLORS.navyLight}`,
+            }}>
+              <div style={{ fontFamily: "'Outfit'", fontSize: 12, color: COLORS.gray, marginBottom: 8 }}>{m.label}</div>
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <span style={{ fontFamily: "'JetBrains Mono'", fontSize: 14, color: COLORS.red }}>{m.before}</span>
+                <span style={{ color: COLORS.gray, fontSize: 16 }}>&#8594;</span>
+                <span style={{ fontFamily: "'JetBrains Mono'", fontSize: 14, color: COLORS.teal }}>{m.after}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </Section>
+  );
+}
+
+// ─── Architecture Diagram ───
+function ArchitectureSection() {
+  const [ref, inView] = useInView(0.15);
+  const [hoveredNode, setHoveredNode] = useState(null);
+
+  const nodes = {
+    github: { label: "GitHub", sub: "Issue Created (Webhook)", x: 0, y: 1, color: COLORS.white, icon: "🐙" },
+    argoEvents: { label: "Argo Events", sub: "EventSource + Sensor", x: 1, y: 0.5, color: COLORS.teal, icon: "⚡" },
+    step1: { label: "1. Fetch Issue", sub: "GitHub MCP Server", x: 2, y: 0, color: COLORS.gold, icon: "📥" },
+    step2: { label: "2. LLM Analysis", sub: "Requirement extraction", x: 2, y: 1, color: COLORS.teal, icon: "🧠" },
+    step3: { label: "3. Create Jira", sub: "Atlassian MCP", x: 2, y: 2, color: COLORS.gold, icon: "📝" },
+    jira: { label: "Atlassian Jira", sub: "FR & NFR Structured Output", x: 3, y: 1, color: COLORS.white, icon: "🎫" },
+  };
+
+  return (
+    <Section id="architecture">
+      <div ref={ref} style={{ maxWidth: 1000, width: "100%" }}>
+        <div style={{
+          fontFamily: "'JetBrains Mono'", fontSize: 12, color: COLORS.teal,
+          letterSpacing: "0.15em", textTransform: "uppercase", marginBottom: 12,
+        }}>Solution Architecture</div>
+        <h2 style={{
+          fontFamily: "'Outfit'", fontWeight: 800, fontSize: "clamp(26px,3.5vw,42px)",
+          color: COLORS.white, margin: "0 0 8px",
+        }}>Event-Driven Intake Pipeline</h2>
+        <p style={{
+          fontFamily: "'Outfit'", fontSize: 15, color: COLORS.gray, marginBottom: 40,
+        }}>Running on Kubernetes (EKS/AKS) with Argo Workflows and MCP Protocol</p>
+
+        {/* Architecture visual */}
+        <div style={{
+          display: "grid", gridTemplateColumns: "1fr 1fr 1fr 1fr",
+          gap: 16, position: "relative",
+        }}>
+          {Object.entries(nodes).map(([key, node], i) => (
+            <div
+              key={key}
+              onMouseEnter={() => setHoveredNode(key)}
+              onMouseLeave={() => setHoveredNode(null)}
+              style={{
+                gridColumn: node.x + 1,
+                gridRow: node.y + 1,
+                background: hoveredNode === key ? COLORS.cardHover : COLORS.card,
+                borderRadius: 12,
+                border: `2px solid ${hoveredNode === key ? node.color : COLORS.navyLight}`,
+                padding: 20, textAlign: "center", cursor: "pointer",
+                opacity: inView ? 1 : 0,
+                transform: inView
+                  ? (hoveredNode === key ? "scale(1.05)" : "scale(1)")
+                  : "translateY(30px)",
+                transition: `all 0.5s ease ${i * 0.1}s`,
+                boxShadow: hoveredNode === key ? `0 8px 32px ${node.color}22` : "none",
+              }}
+            >
+              <div style={{ fontSize: 28, marginBottom: 8 }}>{node.icon}</div>
+              <div style={{
+                fontFamily: "'Outfit'", fontWeight: 700, fontSize: 14,
+                color: COLORS.white,
+              }}>{node.label}</div>
+              <div style={{
+                fontFamily: "'JetBrains Mono'", fontSize: 11, color: node.color,
+                marginTop: 4, opacity: 0.8,
+              }}>{node.sub}</div>
+            </div>
+          ))}
+        </div>
+
+        {/* Key Technologies */}
+        <div style={{
+          display: "flex", gap: 12, marginTop: 40, flexWrap: "wrap", justifyContent: "center",
+        }}>
+          {[
+            { name: "Argo Events", desc: "Event-driven triggers", color: COLORS.teal },
+            { name: "Argo Workflows", desc: "DAG orchestration", color: COLORS.teal },
+            { name: "MCP Protocol", desc: "Tool integration", color: COLORS.gold },
+            { name: "LLM (Bedrock/Azure)", desc: "Requirement extraction", color: COLORS.teal },
+          ].map((t, i) => (
+            <div key={t.name} style={{
+              background: COLORS.card, borderRadius: 8, padding: "12px 20px",
+              borderTop: `3px solid ${t.color}`, textAlign: "center", flex: "1 0 180px",
+              opacity: inView ? 1 : 0,
+              transition: `opacity 0.5s ease ${0.5 + i * 0.1}s`,
+            }}>
+              <div style={{ fontFamily: "'Outfit'", fontWeight: 600, fontSize: 14, color: COLORS.white }}>{t.name}</div>
+              <div style={{ fontFamily: "'JetBrains Mono'", fontSize: 11, color: COLORS.gray, marginTop: 2 }}>{t.desc}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </Section>
+  );
+}
+
+// ─── Pipeline Simulator ───
+function SimulatorSection() {
+  const [ref, inView] = useInView(0.1);
+  const [running, setRunning] = useState(false);
+  const [step, setStep] = useState(-1);
+  const [logs, setLogs] = useState([]);
+  const [ticketResult, setTicketResult] = useState(null);
+  const timerRef = useRef(null);
+
+  const pipeline = [
+    { name: "GitHub Webhook Received", duration: 400, icon: "🐙", log: "Event: issues.opened on repo cloud-platform/intake" },
+    { name: "Argo EventSource Triggered", duration: 600, icon: "⚡", log: "Sensor matched: github-issue-sensor → trigger workflow" },
+    { name: "Fetching Issue via MCP", duration: 800, icon: "📥", log: "MCP:github:get_issue → fetched issue #347: 'Add rate limiting to API gateway'" },
+    { name: "LLM Analyzing Requirements", duration: 2000, icon: "🧠", log: "Extracting FR/NFR... Classifying priority... Generating acceptance criteria..." },
+    { name: "Creating Jira Ticket", duration: 600, icon: "📝", log: "MCP:atlassian:create_issue → PLAT-1892 created in Cloud Platform backlog" },
+    { name: "Human Review Ready", duration: 400, icon: "✅", log: "Notification sent to #platform-intake. Awaiting review." },
+  ];
+
+  const startSimulation = useCallback(() => {
+    setRunning(true);
+    setStep(0);
+    setLogs([]);
+    setTicketResult(null);
+    let current = 0;
+    const runStep = () => {
+      if (current >= pipeline.length) {
+        setRunning(false);
+        setTicketResult({
+          key: "PLAT-1892",
+          title: "Add rate limiting to API gateway",
+          type: "Feature Request",
+          priority: "High",
+          fr: ["Implement token bucket algorithm with configurable rate", "Support per-client rate limiting by API key", "Return 429 status with Retry-After header"],
+          nfr: ["P99 latency impact < 2ms", "Support 50k req/s throughput", "Configuration changes without pod restart"],
+        });
+        return;
+      }
+      setStep(current);
+      setLogs(prev => [...prev, { time: new Date().toLocaleTimeString(), ...pipeline[current] }]);
+      current++;
+      timerRef.current = setTimeout(runStep, pipeline[current - 1].duration);
+    };
+    runStep();
+  }, []);
+
+  useEffect(() => () => clearTimeout(timerRef.current), []);
+
+  return (
+    <Section id="simulator" dark={false} style={{ background: `linear-gradient(180deg, ${COLORS.navy} 0%, ${COLORS.bg} 100%)` }}>
+      <div ref={ref} style={{ maxWidth: 1000, width: "100%" }}>
+        <div style={{
+          fontFamily: "'JetBrains Mono'", fontSize: 12, color: COLORS.teal,
+          letterSpacing: "0.15em", textTransform: "uppercase", marginBottom: 12,
+        }}>Interactive Demo</div>
+        <h2 style={{
+          fontFamily: "'Outfit'", fontWeight: 800, fontSize: "clamp(26px,3.5vw,42px)",
+          color: COLORS.white, margin: "0 0 8px",
+        }}>Pipeline Simulator</h2>
+        <p style={{
+          fontFamily: "'Outfit'", fontSize: 15, color: COLORS.gray, marginBottom: 32,
+        }}>Watch the intelligent ticket pipeline process a GitHub issue in real time</p>
+
+        {/* Run button */}
+        <button
+          onClick={startSimulation}
+          disabled={running}
+          style={{
+            background: running ? COLORS.grayDark : COLORS.teal,
+            color: running ? COLORS.gray : COLORS.navy,
+            fontFamily: "'Outfit'", fontWeight: 700, fontSize: 16,
+            padding: "14px 36px", borderRadius: 10, border: "none",
+            cursor: running ? "default" : "pointer",
+            marginBottom: 32, transition: "all 0.3s",
+            boxShadow: running ? "none" : `0 4px 24px rgba(45,212,168,0.3)`,
+          }}
+        >
+          {running ? "Running Pipeline..." : "▶  Run Pipeline"}
+        </button>
+
+        {/* Pipeline steps */}
+        <div style={{
+          display: "flex", gap: 4, marginBottom: 24, flexWrap: "wrap", justifyContent: "center",
+        }}>
+          {pipeline.map((p, i) => {
+            const isActive = i === step;
+            const isDone = i < step || (!running && step >= pipeline.length - 1 && i <= pipeline.length - 1);
+            const finalDone = !running && ticketResult && i <= pipeline.length - 1;
+            return (
+              <div key={i} style={{
+                flex: "1 0 120px", maxWidth: 160,
+                background: isActive ? COLORS.teal + "22" : COLORS.card,
+                borderRadius: 8, padding: "12px 10px", textAlign: "center",
+                border: `2px solid ${isActive ? COLORS.teal : finalDone ? COLORS.teal + "55" : COLORS.navyLight}`,
+                transition: "all 0.3s",
+                opacity: inView ? 1 : 0.3,
+              }}>
+                <div style={{
+                  fontSize: 22, marginBottom: 4,
+                  filter: isActive ? "none" : "grayscale(0.5)",
+                  transition: "filter 0.3s",
+                }}>{p.icon}</div>
+                <div style={{
+                  fontFamily: "'Outfit'", fontWeight: 600, fontSize: 11,
+                  color: isActive ? COLORS.teal : finalDone ? COLORS.white : COLORS.gray,
+                }}>{p.name}</div>
+                {isActive && (
+                  <div style={{
+                    width: 16, height: 16, border: `2px solid ${COLORS.teal}`,
+                    borderTop: "2px solid transparent", borderRadius: "50%",
+                    margin: "6px auto 0",
+                    animation: "spin 0.8s linear infinite",
+                  }} />
+                )}
+                {finalDone && !isActive && (
+                  <div style={{ color: COLORS.teal, fontSize: 14, marginTop: 4 }}>&#10003;</div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Log output */}
+        <div style={{
+          background: "#0a0e1a", borderRadius: 10, padding: 20,
+          border: `1px solid ${COLORS.navyLight}`,
+          fontFamily: "'JetBrains Mono'", fontSize: 12, color: COLORS.gray,
+          minHeight: 140, maxHeight: 200, overflowY: "auto",
+        }}>
+          {logs.length === 0 && <span style={{ opacity: 0.5 }}>$ awaiting pipeline execution...</span>}
+          {logs.map((l, i) => (
+            <div key={i} style={{ marginBottom: 6, lineHeight: 1.5 }}>
+              <span style={{ color: COLORS.grayDark }}>[{l.time}]</span>{" "}
+              <span style={{ color: COLORS.teal }}>{l.icon} {l.name}</span>
+              <br />
+              <span style={{ color: COLORS.gray, paddingLeft: 20 }}>{l.log}</span>
+            </div>
+          ))}
+        </div>
+
+        {/* Ticket result */}
+        {ticketResult && (
+          <div style={{
+            background: COLORS.card, borderRadius: 12, padding: 24, marginTop: 20,
+            border: `2px solid ${COLORS.teal}`,
+            animation: "fadeIn 0.5s ease",
+          }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16, flexWrap: "wrap", gap: 8 }}>
+              <div>
+                <span style={{
+                  fontFamily: "'JetBrains Mono'", fontSize: 13, color: COLORS.teal,
+                  background: "rgba(45,212,168,0.15)", padding: "3px 10px", borderRadius: 4,
+                }}>{ticketResult.key}</span>
+                <span style={{
+                  fontFamily: "'Outfit'", fontSize: 16, fontWeight: 600, color: COLORS.white,
+                  marginLeft: 12,
+                }}>{ticketResult.title}</span>
+              </div>
+              <div style={{ display: "flex", gap: 8 }}>
+                <span style={{
+                  fontSize: 11, fontFamily: "'JetBrains Mono'", color: COLORS.gold,
+                  background: "rgba(244,162,97,0.15)", padding: "3px 10px", borderRadius: 4,
+                }}>{ticketResult.priority}</span>
+                <span style={{
+                  fontSize: 11, fontFamily: "'JetBrains Mono'", color: COLORS.teal,
+                  background: "rgba(45,212,168,0.15)", padding: "3px 10px", borderRadius: 4,
+                }}>{ticketResult.type}</span>
+              </div>
+            </div>
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
+              <div>
+                <div style={{ fontFamily: "'Outfit'", fontWeight: 600, fontSize: 13, color: COLORS.teal, marginBottom: 8 }}>
+                  Functional Requirements
+                </div>
+                {ticketResult.fr.map((r, i) => (
+                  <div key={i} style={{
+                    fontFamily: "'Outfit'", fontSize: 13, color: COLORS.gray,
+                    padding: "4px 0", borderBottom: `1px solid ${COLORS.navyLight}`,
+                    lineHeight: 1.5,
+                  }}>&#8226; {r}</div>
+                ))}
+              </div>
+              <div>
+                <div style={{ fontFamily: "'Outfit'", fontWeight: 600, fontSize: 13, color: COLORS.gold, marginBottom: 8 }}>
+                  Non-Functional Requirements
+                </div>
+                {ticketResult.nfr.map((r, i) => (
+                  <div key={i} style={{
+                    fontFamily: "'Outfit'", fontSize: 13, color: COLORS.gray,
+                    padding: "4px 0", borderBottom: `1px solid ${COLORS.navyLight}`,
+                    lineHeight: 1.5,
+                  }}>&#8226; {r}</div>
+                ))}
+              </div>
+            </div>
+            <div style={{
+              marginTop: 16, fontFamily: "'JetBrains Mono'", fontSize: 12,
+              color: COLORS.teal, opacity: 0.8,
+            }}>
+              Total pipeline duration: ~4.8 seconds &middot; 10x faster than manual process
+            </div>
+          </div>
+        )}
+      </div>
+    </Section>
+  );
+}
+
+// ─── Metrics Dashboard ───
+function MetricsSection() {
+  const [ref, inView] = useInView(0.2);
+  const metrics = [
+    { label: "Lead Time", before: "45+ min", after: "< 5 min", improvement: "10x", sublabel: "Argo Workflow duration", color: COLORS.teal },
+    { label: "Process Efficiency", before: "56%", after: "95%+", improvement: "Near-optimal", sublabel: "Value-add / Total time", color: COLORS.teal },
+    { label: "Ticket Quality", before: "~30% rework", after: "< 5% rework", improvement: "6x", sublabel: "Jira ticket reopen rate", color: COLORS.gold },
+    { label: "Throughput", before: "~10/day", after: "Unlimited*", improvement: "Scales", sublabel: "Kubernetes autoscaling", color: COLORS.teal },
+  ];
+
+  const definitions = [
+    { term: "Takt Time", def: "Available time / Customer demand. Sets the pace for sustainable delivery." },
+    { term: "Cycle Time", def: "Time to complete one unit of work. Target: < 5 minutes per ticket." },
+    { term: "Process Efficiency", def: "Value-add time / Total lead time. Higher = less waste." },
+    { term: "First Pass Yield", def: "% of tickets accepted without rework. Quality indicator." },
+  ];
+
+  return (
+    <Section id="metrics">
+      <div ref={ref} style={{ maxWidth: 1000, width: "100%" }}>
+        <div style={{
+          fontFamily: "'JetBrains Mono'", fontSize: 12, color: COLORS.teal,
+          letterSpacing: "0.15em", textTransform: "uppercase", marginBottom: 12,
+        }}>Measuring Success</div>
+        <h2 style={{
+          fontFamily: "'Outfit'", fontWeight: 800, fontSize: "clamp(26px,3.5vw,42px)",
+          color: COLORS.white, margin: "0 0 32px",
+        }}>Key Metrics for Cycle Time and Quality</h2>
+
+        <div style={{
+          display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+          gap: 16, marginBottom: 40,
+        }}>
+          {metrics.map((m, i) => (
+            <div key={m.label} style={{
+              background: COLORS.card, borderRadius: 12, padding: 24,
+              border: `1px solid ${COLORS.navyLight}`,
+              opacity: inView ? 1 : 0,
+              transform: inView ? "translateY(0)" : "translateY(20px)",
+              transition: `all 0.5s ease ${i * 0.1}s`,
+            }}>
+              <div style={{ fontFamily: "'Outfit'", fontWeight: 600, fontSize: 16, color: COLORS.white, marginBottom: 16 }}>{m.label}</div>
+              <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 8 }}>
+                <div>
+                  <div style={{ fontFamily: "'JetBrains Mono'", fontSize: 11, color: COLORS.gray }}>Before</div>
+                  <div style={{ fontFamily: "'JetBrains Mono'", fontSize: 16, color: COLORS.red, fontWeight: 600 }}>{m.before}</div>
+                </div>
+                <div style={{ textAlign: "right" }}>
+                  <div style={{ fontFamily: "'JetBrains Mono'", fontSize: 11, color: COLORS.gray }}>After</div>
+                  <div style={{ fontFamily: "'JetBrains Mono'", fontSize: 16, color: COLORS.teal, fontWeight: 600 }}>{m.after}</div>
+                </div>
+              </div>
+              {/* Progress bar */}
+              <div style={{ height: 6, background: COLORS.navyLight, borderRadius: 3, overflow: "hidden", marginBottom: 12 }}>
+                <div style={{
+                  height: "100%", background: `linear-gradient(90deg, ${COLORS.red}, ${m.color})`,
+                  width: inView ? "100%" : "0%",
+                  borderRadius: 3,
+                  transition: `width 1.2s ease ${0.3 + i * 0.15}s`,
+                }} />
+              </div>
+              <div style={{
+                fontFamily: "'Outfit'", fontWeight: 700, fontSize: 14,
+                color: COLORS.navy, background: m.color,
+                display: "inline-block", padding: "4px 14px", borderRadius: 6,
+              }}>{m.improvement}{m.improvement !== "Near-optimal" && m.improvement !== "Scales" ? " faster" : ""}</div>
+              <div style={{ fontFamily: "'JetBrains Mono'", fontSize: 11, color: COLORS.grayDark, marginTop: 8 }}>{m.sublabel}</div>
+            </div>
+          ))}
+        </div>
+
+        {/* Definitions */}
+        <div style={{
+          background: COLORS.card, borderRadius: 12, padding: 24,
+          border: `1px solid ${COLORS.navyLight}`,
+        }}>
+          <div style={{
+            fontFamily: "'Outfit'", fontWeight: 600, fontSize: 16, color: COLORS.white,
+            marginBottom: 16,
+          }}>Value Stream Metrics Explained</div>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 16 }}>
+            {definitions.map(d => (
+              <div key={d.term}>
+                <div style={{ fontFamily: "'Outfit'", fontWeight: 600, fontSize: 13, color: COLORS.teal }}>{d.term}</div>
+                <div style={{ fontFamily: "'Outfit'", fontSize: 13, color: COLORS.gray, lineHeight: 1.5, marginTop: 4 }}>{d.def}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </Section>
+  );
+}
+
+// ─── Main App ───
+export default function App() {
+  const [active, setActive] = useState("hero");
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const sections = ["hero", "problem", "vsm", "architecture", "simulator", "metrics"];
+      for (const id of [...sections].reverse()) {
+        const el = document.getElementById(id);
+        if (el && el.getBoundingClientRect().top <= 200) {
+          setActive(id);
+          break;
+        }
+      }
+    };
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  return (
+    <div style={{
+      fontFamily: "'Outfit', sans-serif", background: COLORS.bg,
+      minHeight: "100vh", color: COLORS.white,
+    }}>
+      <style>{fonts}{`
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        html { scroll-behavior: smooth; }
+        ::-webkit-scrollbar { width: 6px; }
+        ::-webkit-scrollbar-track { background: ${COLORS.bg}; }
+        ::-webkit-scrollbar-thumb { background: ${COLORS.navyLight}; border-radius: 3px; }
+        @keyframes spin { to { transform: rotate(360deg); } }
+        @keyframes fadeIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
+      `}</style>
+      <Nav active={active} />
+      <Hero />
+      <ProblemSection />
+      <VSMSection />
+      <ArchitectureSection />
+      <SimulatorSection />
+      <MetricsSection />
+      {/* Footer */}
+      <footer style={{
+        textAlign: "center", padding: "40px 24px", background: COLORS.bg,
+        borderTop: `1px solid ${COLORS.navyLight}`,
+      }}>
+        <div style={{ fontFamily: "'Outfit'", fontWeight: 600, fontSize: 18, color: COLORS.white, marginBottom: 8 }}>
+          Thank You
+        </div>
+        <div style={{ fontFamily: "'JetBrains Mono'", fontSize: 12, color: COLORS.gray }}>
+          Gonzalo Vazquez &middot; KCD Toronto 2026 &middot; gonzalovazquez.ca
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,0 +1,1776 @@
+{
+  "name": "ai-ticketing-pipeline-ui",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ai-ticketing-pipeline-ui",
+      "version": "1.0.0",
+      "dependencies": {
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-react": "^4.5.2",
+        "vite": "^6.3.5"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.29",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
+      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.353",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.353.tgz",
+      "integrity": "sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ai-ticketing-pipeline-ui",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.5.2",
+    "vite": "^6.3.5"
+  }
+}

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -1,0 +1,858 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+
+const COLORS = {
+  navy: "#1a2744",
+  navyLight: "#243352",
+  teal: "#2dd4a8",
+  tealDark: "#1fa882",
+  red: "#e63946",
+  redDark: "#c1121f",
+  gold: "#f4a261",
+  white: "#f8f9fa",
+  gray: "#94a3b8",
+  grayDark: "#475569",
+  bg: "#0f1729",
+  card: "#1e293b",
+  cardHover: "#263548",
+};
+
+const fonts = `
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&family=Outfit:wght@300;400;500;600;700;800;900&display=swap');
+`;
+
+// ─── Utility: Intersection Observer Hook ───
+function useInView(threshold = 0.2) {
+  const ref = useRef(null);
+  const [inView, setInView] = useState(false);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const obs = new IntersectionObserver(
+      ([e]) => { if (e.isIntersecting) setInView(true); },
+      { threshold }
+    );
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, [threshold]);
+  return [ref, inView];
+}
+
+// ─── Animated Counter ───
+function Counter({ end, duration = 1500, suffix = "", prefix = "", inView }) {
+  const [val, setVal] = useState(0);
+  useEffect(() => {
+    if (!inView) return;
+    let start = 0;
+    const step = end / (duration / 16);
+    const id = setInterval(() => {
+      start += step;
+      if (start >= end) { setVal(end); clearInterval(id); }
+      else setVal(Math.floor(start));
+    }, 16);
+    return () => clearInterval(id);
+  }, [inView, end, duration]);
+  return <span>{prefix}{val}{suffix}</span>;
+}
+
+// ─── Section Wrapper ───
+function Section({ id, children, dark = true, style = {} }) {
+  const [ref, inView] = useInView(0.1);
+  return (
+    <section
+      ref={ref}
+      id={id}
+      style={{
+        minHeight: "100vh",
+        padding: "100px 24px",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        background: dark ? COLORS.bg : COLORS.navy,
+        position: "relative",
+        opacity: inView ? 1 : 0,
+        transform: inView ? "translateY(0)" : "translateY(40px)",
+        transition: "opacity 0.8s ease, transform 0.8s ease",
+        ...style,
+      }}
+    >
+      {children}
+    </section>
+  );
+}
+
+// ─── Navigation ───
+function Nav({ active }) {
+  const items = [
+    { id: "hero", label: "Home" },
+    { id: "problem", label: "Problem" },
+    { id: "vsm", label: "Value Stream" },
+    { id: "architecture", label: "Architecture" },
+    { id: "simulator", label: "Simulator" },
+    { id: "metrics", label: "Metrics" },
+  ];
+  return (
+    <nav style={{
+      position: "fixed", top: 0, left: 0, right: 0, zIndex: 100,
+      background: "rgba(15,23,41,0.85)", backdropFilter: "blur(16px)",
+      borderBottom: `1px solid ${COLORS.navyLight}`,
+      display: "flex", justifyContent: "center", gap: 8, padding: "12px 16px",
+    }}>
+      <span style={{
+        fontFamily: "'JetBrains Mono'", fontWeight: 700, color: COLORS.teal,
+        fontSize: 14, marginRight: "auto", paddingLeft: 8,
+        letterSpacing: "0.05em",
+      }}>KCD Toronto 2026</span>
+      {items.map(it => (
+        <a key={it.id} href={`#${it.id}`} style={{
+          color: active === it.id ? COLORS.teal : COLORS.gray,
+          textDecoration: "none", fontSize: 13, fontFamily: "'Outfit'",
+          fontWeight: active === it.id ? 600 : 400,
+          padding: "4px 12px", borderRadius: 6,
+          background: active === it.id ? "rgba(45,212,168,0.1)" : "transparent",
+          transition: "all 0.2s",
+        }}>{it.label}</a>
+      ))}
+    </nav>
+  );
+}
+
+// ─── Hero ───
+function Hero() {
+  const [loaded, setLoaded] = useState(false);
+  useEffect(() => { setTimeout(() => setLoaded(true), 100); }, []);
+  return (
+    <section id="hero" style={{
+      minHeight: "100vh", display: "flex", flexDirection: "column",
+      alignItems: "center", justifyContent: "center", textAlign: "center",
+      background: `radial-gradient(ellipse at 50% 30%, ${COLORS.navyLight} 0%, ${COLORS.bg} 70%)`,
+      padding: "60px 24px", position: "relative", overflow: "hidden",
+    }}>
+      {/* Grid background */}
+      <div style={{
+        position: "absolute", inset: 0, opacity: 0.06,
+        backgroundImage: `linear-gradient(${COLORS.teal} 1px, transparent 1px), linear-gradient(90deg, ${COLORS.teal} 1px, transparent 1px)`,
+        backgroundSize: "60px 60px",
+      }} />
+      {/* Glow */}
+      <div style={{
+        position: "absolute", top: "20%", left: "50%", transform: "translate(-50%,-50%)",
+        width: 600, height: 600, borderRadius: "50%",
+        background: `radial-gradient(circle, rgba(45,212,168,0.12) 0%, transparent 70%)`,
+        filter: "blur(60px)",
+      }} />
+      <div style={{
+        position: "relative", zIndex: 1,
+        opacity: loaded ? 1 : 0, transform: loaded ? "translateY(0)" : "translateY(30px)",
+        transition: "all 1s ease 0.2s",
+      }}>
+        <div style={{
+          fontFamily: "'JetBrains Mono'", fontSize: 13, color: COLORS.teal,
+          letterSpacing: "0.2em", textTransform: "uppercase", marginBottom: 24,
+          background: "rgba(45,212,168,0.1)", display: "inline-block",
+          padding: "6px 20px", borderRadius: 20, border: `1px solid rgba(45,212,168,0.2)`,
+        }}>KCD Toronto 2026</div>
+        <h1 style={{
+          fontFamily: "'Outfit'", fontWeight: 900, fontSize: "clamp(42px, 7vw, 86px)",
+          color: COLORS.white, lineHeight: 1.05, margin: "16px 0",
+          maxWidth: 800,
+        }}>
+          Reducing Cycle Time{" "}
+          <span style={{ color: COLORS.teal }}>10x</span>
+        </h1>
+        <p style={{
+          fontFamily: "'Outfit'", fontWeight: 300, fontSize: "clamp(18px, 2.5vw, 26px)",
+          color: COLORS.teal, margin: "12px 0 32px", maxWidth: 600,
+        }}>
+          Building an Intelligent Ticket Pipeline on Kubernetes
+        </p>
+        <div style={{
+          fontFamily: "'Outfit'", fontSize: 15, color: COLORS.gray, marginBottom: 40,
+        }}>
+          Gonzalo Vazquez &middot; Director, Cloud Engineering &middot; Royal Bank of Canada
+        </div>
+        <a href="#problem" style={{
+          display: "inline-flex", alignItems: "center", gap: 8,
+          background: COLORS.teal, color: COLORS.navy, fontFamily: "'Outfit'",
+          fontWeight: 600, fontSize: 15, padding: "14px 32px", borderRadius: 8,
+          textDecoration: "none", transition: "transform 0.2s, box-shadow 0.2s",
+          boxShadow: "0 4px 24px rgba(45,212,168,0.3)",
+        }}>
+          Explore the Pipeline &#8595;
+        </a>
+      </div>
+    </section>
+  );
+}
+
+// ─── Problem Statement ───
+function ProblemSection() {
+  const [ref, inView] = useInView(0.2);
+  const wastes = [
+    { name: "Overproduction", icon: "📦", desc: "Creating tickets nobody asked for" },
+    { name: "Waiting Time", icon: "⏳", desc: "Queuing for human review" },
+    { name: "Superfluous Movement", icon: "🔄", desc: "Context switching between tools" },
+    { name: "Transport", icon: "🚚", desc: "Moving data across systems manually" },
+    { name: "Overprocessing", icon: "⚙️", desc: "Redundant analysis steps" },
+    { name: "Inventory/Stock", icon: "📋", desc: "Backlog of unprocessed requests" },
+    { name: "Defects & Rework", icon: "🔁", desc: "~30% ticket reopen rate" },
+  ];
+  return (
+    <Section id="problem">
+      <div ref={ref} style={{ maxWidth: 1000, width: "100%" }}>
+        <div style={{
+          fontFamily: "'JetBrains Mono'", fontSize: 12, color: COLORS.teal,
+          letterSpacing: "0.15em", textTransform: "uppercase", marginBottom: 12,
+        }}>The Problem</div>
+        <h2 style={{
+          fontFamily: "'Outfit'", fontWeight: 800, fontSize: "clamp(28px,4vw,48px)",
+          color: COLORS.white, margin: "0 0 12px",
+        }}>
+          AI optimizes processes...{" "}
+          <span style={{ color: COLORS.gray, fontWeight: 300 }}>
+            if we know how to measure them.
+          </span>
+        </h2>
+        <p style={{
+          fontFamily: "'Outfit'", fontSize: 17, color: COLORS.gray, maxWidth: 650,
+          lineHeight: 1.6, marginBottom: 48,
+        }}>
+          A process is standardized and repeatable. Value is added when the output
+          is greater than the input. The Japanese concept of <em>Muda</em> teaches
+          us to eliminate waste to maximize value.
+        </p>
+        <h3 style={{
+          fontFamily: "'Outfit'", fontWeight: 600, fontSize: 20, color: COLORS.white,
+          marginBottom: 24,
+        }}>Seven Types of Waste (Muda)</h3>
+        <div style={{
+          display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
+          gap: 12,
+        }}>
+          {wastes.map((w, i) => (
+            <div key={w.name} style={{
+              background: COLORS.card, borderRadius: 10, padding: "18px 16px",
+              border: `1px solid ${COLORS.navyLight}`,
+              opacity: inView ? 1 : 0,
+              transform: inView ? "translateY(0)" : "translateY(20px)",
+              transition: `all 0.5s ease ${i * 0.07}s`,
+            }}>
+              <div style={{ fontSize: 24, marginBottom: 6 }}>{w.icon}</div>
+              <div style={{
+                fontFamily: "'Outfit'", fontWeight: 600, fontSize: 14,
+                color: COLORS.white, marginBottom: 4,
+              }}>{w.name}</div>
+              <div style={{
+                fontFamily: "'Outfit'", fontSize: 12, color: COLORS.gray, lineHeight: 1.4,
+              }}>{w.desc}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </Section>
+  );
+}
+
+// ─── Value Stream Map ───
+function VSMSection() {
+  const [ref, inView] = useInView(0.15);
+  const [showFuture, setShowFuture] = useState(false);
+
+  const currentSteps = [
+    { name: "Issue Created", ct: "2 min", wait: null, color: COLORS.red },
+    { name: "Queue for Review", ct: "N/A", wait: "15 min", color: COLORS.red },
+    { name: "Manual Analysis", ct: "12 min", wait: null, color: COLORS.red },
+    { name: "Clarification", ct: "5 min", wait: "8 min", color: COLORS.red },
+    { name: "Write Requirements", ct: "10 min", wait: null, color: COLORS.red },
+    { name: "Create Jira Ticket", ct: "5 min", wait: null, color: COLORS.red },
+  ];
+
+  const futureSteps = [
+    { name: "Issue Created", ct: "1 min", wait: null, color: COLORS.teal, auto: false },
+    { name: "Webhook Trigger", ct: "< 1 sec", wait: null, color: COLORS.teal, auto: true },
+    { name: "AI Analysis (LLM + MCP)", ct: "2 min", wait: null, color: COLORS.teal, auto: true },
+    { name: "Auto-Create Jira", ct: "30 sec", wait: null, color: COLORS.teal, auto: true },
+    { name: "Human Review", ct: "1 min", wait: null, color: COLORS.teal, auto: false },
+  ];
+
+  const steps = showFuture ? futureSteps : currentSteps;
+  const title = showFuture ? "Future State" : "Current State";
+  const leadTime = showFuture ? "< 5 minutes" : "45+ minutes";
+
+  return (
+    <Section id="vsm" dark={false}>
+      <div ref={ref} style={{ maxWidth: 1100, width: "100%" }}>
+        <div style={{
+          fontFamily: "'JetBrains Mono'", fontSize: 12, color: COLORS.teal,
+          letterSpacing: "0.15em", textTransform: "uppercase", marginBottom: 12,
+        }}>Value Stream Map</div>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: 16, marginBottom: 32 }}>
+          <div>
+            <h2 style={{
+              fontFamily: "'Outfit'", fontWeight: 800, fontSize: "clamp(26px,3.5vw,42px)",
+              color: COLORS.white, margin: 0,
+            }}>{title} Value Stream Map</h2>
+            <p style={{
+              fontFamily: "'Outfit'", fontSize: 15, color: COLORS.gray, margin: "4px 0 0",
+            }}>
+              {showFuture ? "Automated Pipeline" : "Manual Intake Process"} &mdash; Lead Time: {" "}
+              <span style={{ color: showFuture ? COLORS.teal : COLORS.red, fontWeight: 600 }}>{leadTime}</span>
+            </p>
+          </div>
+          <button onClick={() => setShowFuture(!showFuture)} style={{
+            background: showFuture ? COLORS.red : COLORS.teal,
+            color: showFuture ? COLORS.white : COLORS.navy,
+            fontFamily: "'Outfit'", fontWeight: 600, fontSize: 14,
+            padding: "10px 24px", borderRadius: 8, border: "none", cursor: "pointer",
+            transition: "all 0.3s",
+          }}>
+            {showFuture ? "Show Current State" : "Show Future State"}
+          </button>
+        </div>
+
+        {/* Process Steps */}
+        <div style={{
+          display: "flex", gap: 8, overflowX: "auto", paddingBottom: 16,
+        }}>
+          {steps.map((s, i) => (
+            <div key={`${showFuture}-${i}`} style={{
+              flex: "1 0 140px", minWidth: 140,
+              background: COLORS.card, borderRadius: 10,
+              border: `2px solid ${s.color}`,
+              padding: 16, textAlign: "center",
+              opacity: inView ? 1 : 0,
+              transform: inView ? "translateY(0)" : "translateY(20px)",
+              transition: `all 0.4s ease ${i * 0.08}s`,
+            }}>
+              <div style={{
+                fontFamily: "'Outfit'", fontWeight: 600, fontSize: 14,
+                color: COLORS.white, marginBottom: 8, minHeight: 36,
+              }}>{s.name}</div>
+              <div style={{
+                fontFamily: "'JetBrains Mono'", fontSize: 12, color: s.color,
+              }}>C/T: {s.ct}</div>
+              {s.wait && (
+                <div style={{
+                  fontFamily: "'JetBrains Mono'", fontSize: 12, color: COLORS.gold,
+                  marginTop: 4,
+                }}>Wait: {s.wait}</div>
+              )}
+              {s.auto !== undefined && (
+                <div style={{
+                  marginTop: 8, fontSize: 10, fontFamily: "'JetBrains Mono'",
+                  color: s.auto ? COLORS.teal : COLORS.gray,
+                  background: s.auto ? "rgba(45,212,168,0.15)" : "rgba(148,163,184,0.15)",
+                  padding: "3px 10px", borderRadius: 10, display: "inline-block",
+                  fontWeight: 600,
+                }}>{s.auto ? "AUTOMATED" : "MANUAL"}</div>
+              )}
+              {/* Arrow */}
+              {i < steps.length - 1 && (
+                <div style={{
+                  position: "absolute", right: -16, top: "50%", color: COLORS.gray,
+                  fontSize: 18,
+                }}>&#8594;</div>
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* Timeline bar */}
+        <div style={{
+          display: "flex", marginTop: 16, height: 28, borderRadius: 6, overflow: "hidden",
+          background: COLORS.card,
+        }}>
+          {steps.map((s, i) => {
+            const widths = showFuture ? [20, 2, 45, 13, 20] : [4, 28, 22, 24, 18, 9];
+            return (
+              <div key={i} style={{
+                flex: `${widths[i]} 0 0`,
+                background: s.wait ? COLORS.red + "55" : s.color + "44",
+                display: "flex", alignItems: "center", justifyContent: "center",
+                fontFamily: "'JetBrains Mono'", fontSize: 10, color: COLORS.white,
+                borderRight: i < steps.length - 1 ? `1px solid ${COLORS.bg}` : "none",
+                transition: "all 0.5s ease",
+              }}>
+                {s.ct}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Metrics comparison */}
+        <div style={{
+          display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+          gap: 12, marginTop: 32,
+        }}>
+          {[
+            { label: "Process Efficiency", before: "56%", after: "95%+" },
+            { label: "Quality Issues", before: "~30% rework", after: "< 5% rework" },
+            { label: "Bottleneck", before: "Human queue", after: "None (event-driven)" },
+          ].map((m, i) => (
+            <div key={m.label} style={{
+              background: COLORS.card, borderRadius: 8, padding: 16,
+              border: `1px solid ${COLORS.navyLight}`,
+            }}>
+              <div style={{ fontFamily: "'Outfit'", fontSize: 12, color: COLORS.gray, marginBottom: 8 }}>{m.label}</div>
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <span style={{ fontFamily: "'JetBrains Mono'", fontSize: 14, color: COLORS.red }}>{m.before}</span>
+                <span style={{ color: COLORS.gray, fontSize: 16 }}>&#8594;</span>
+                <span style={{ fontFamily: "'JetBrains Mono'", fontSize: 14, color: COLORS.teal }}>{m.after}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </Section>
+  );
+}
+
+// ─── Architecture Diagram ───
+function ArchitectureSection() {
+  const [ref, inView] = useInView(0.15);
+  const [hoveredNode, setHoveredNode] = useState(null);
+
+  const nodes = {
+    github: { label: "GitHub", sub: "Issue Created (Webhook)", x: 0, y: 1, color: COLORS.white, icon: "🐙" },
+    argoEvents: { label: "Argo Events", sub: "EventSource + Sensor", x: 1, y: 0.5, color: COLORS.teal, icon: "⚡" },
+    step1: { label: "1. Fetch Issue", sub: "GitHub MCP Server", x: 2, y: 0, color: COLORS.gold, icon: "📥" },
+    step2: { label: "2. LLM Analysis", sub: "Requirement extraction", x: 2, y: 1, color: COLORS.teal, icon: "🧠" },
+    step3: { label: "3. Create Jira", sub: "Atlassian MCP", x: 2, y: 2, color: COLORS.gold, icon: "📝" },
+    jira: { label: "Atlassian Jira", sub: "FR & NFR Structured Output", x: 3, y: 1, color: COLORS.white, icon: "🎫" },
+  };
+
+  return (
+    <Section id="architecture">
+      <div ref={ref} style={{ maxWidth: 1000, width: "100%" }}>
+        <div style={{
+          fontFamily: "'JetBrains Mono'", fontSize: 12, color: COLORS.teal,
+          letterSpacing: "0.15em", textTransform: "uppercase", marginBottom: 12,
+        }}>Solution Architecture</div>
+        <h2 style={{
+          fontFamily: "'Outfit'", fontWeight: 800, fontSize: "clamp(26px,3.5vw,42px)",
+          color: COLORS.white, margin: "0 0 8px",
+        }}>Event-Driven Intake Pipeline</h2>
+        <p style={{
+          fontFamily: "'Outfit'", fontSize: 15, color: COLORS.gray, marginBottom: 40,
+        }}>Running on Kubernetes (EKS/AKS) with Argo Workflows and MCP Protocol</p>
+
+        {/* Architecture visual */}
+        <div style={{
+          display: "grid", gridTemplateColumns: "1fr 1fr 1fr 1fr",
+          gap: 16, position: "relative",
+        }}>
+          {Object.entries(nodes).map(([key, node], i) => (
+            <div
+              key={key}
+              onMouseEnter={() => setHoveredNode(key)}
+              onMouseLeave={() => setHoveredNode(null)}
+              style={{
+                gridColumn: node.x + 1,
+                gridRow: node.y + 1,
+                background: hoveredNode === key ? COLORS.cardHover : COLORS.card,
+                borderRadius: 12,
+                border: `2px solid ${hoveredNode === key ? node.color : COLORS.navyLight}`,
+                padding: 20, textAlign: "center", cursor: "pointer",
+                opacity: inView ? 1 : 0,
+                transform: inView
+                  ? (hoveredNode === key ? "scale(1.05)" : "scale(1)")
+                  : "translateY(30px)",
+                transition: `all 0.5s ease ${i * 0.1}s`,
+                boxShadow: hoveredNode === key ? `0 8px 32px ${node.color}22` : "none",
+              }}
+            >
+              <div style={{ fontSize: 28, marginBottom: 8 }}>{node.icon}</div>
+              <div style={{
+                fontFamily: "'Outfit'", fontWeight: 700, fontSize: 14,
+                color: COLORS.white,
+              }}>{node.label}</div>
+              <div style={{
+                fontFamily: "'JetBrains Mono'", fontSize: 11, color: node.color,
+                marginTop: 4, opacity: 0.8,
+              }}>{node.sub}</div>
+            </div>
+          ))}
+        </div>
+
+        {/* Key Technologies */}
+        <div style={{
+          display: "flex", gap: 12, marginTop: 40, flexWrap: "wrap", justifyContent: "center",
+        }}>
+          {[
+            { name: "Argo Events", desc: "Event-driven triggers", color: COLORS.teal },
+            { name: "Argo Workflows", desc: "DAG orchestration", color: COLORS.teal },
+            { name: "MCP Protocol", desc: "Tool integration", color: COLORS.gold },
+            { name: "LLM (Bedrock/Azure)", desc: "Requirement extraction", color: COLORS.teal },
+          ].map((t, i) => (
+            <div key={t.name} style={{
+              background: COLORS.card, borderRadius: 8, padding: "12px 20px",
+              borderTop: `3px solid ${t.color}`, textAlign: "center", flex: "1 0 180px",
+              opacity: inView ? 1 : 0,
+              transition: `opacity 0.5s ease ${0.5 + i * 0.1}s`,
+            }}>
+              <div style={{ fontFamily: "'Outfit'", fontWeight: 600, fontSize: 14, color: COLORS.white }}>{t.name}</div>
+              <div style={{ fontFamily: "'JetBrains Mono'", fontSize: 11, color: COLORS.gray, marginTop: 2 }}>{t.desc}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </Section>
+  );
+}
+
+// ─── Pipeline Simulator ───
+function SimulatorSection() {
+  const [ref, inView] = useInView(0.1);
+  const [running, setRunning] = useState(false);
+  const [step, setStep] = useState(-1);
+  const [logs, setLogs] = useState([]);
+  const [ticketResult, setTicketResult] = useState(null);
+  const timerRef = useRef(null);
+
+  const pipeline = [
+    { name: "GitHub Webhook Received", duration: 400, icon: "🐙", log: "Event: issues.opened on repo cloud-platform/intake" },
+    { name: "Argo EventSource Triggered", duration: 600, icon: "⚡", log: "Sensor matched: github-issue-sensor → trigger workflow" },
+    { name: "Fetching Issue via MCP", duration: 800, icon: "📥", log: "MCP:github:get_issue → fetched issue #347: 'Add rate limiting to API gateway'" },
+    { name: "LLM Analyzing Requirements", duration: 2000, icon: "🧠", log: "Extracting FR/NFR... Classifying priority... Generating acceptance criteria..." },
+    { name: "Creating Jira Ticket", duration: 600, icon: "📝", log: "MCP:atlassian:create_issue → PLAT-1892 created in Cloud Platform backlog" },
+    { name: "Human Review Ready", duration: 400, icon: "✅", log: "Notification sent to #platform-intake. Awaiting review." },
+  ];
+
+  const startSimulation = useCallback(() => {
+    setRunning(true);
+    setStep(0);
+    setLogs([]);
+    setTicketResult(null);
+    let current = 0;
+    const runStep = () => {
+      if (current >= pipeline.length) {
+        setRunning(false);
+        setTicketResult({
+          key: "PLAT-1892",
+          title: "Add rate limiting to API gateway",
+          type: "Feature Request",
+          priority: "High",
+          fr: ["Implement token bucket algorithm with configurable rate", "Support per-client rate limiting by API key", "Return 429 status with Retry-After header"],
+          nfr: ["P99 latency impact < 2ms", "Support 50k req/s throughput", "Configuration changes without pod restart"],
+        });
+        return;
+      }
+      setStep(current);
+      setLogs(prev => [...prev, { time: new Date().toLocaleTimeString(), ...pipeline[current] }]);
+      current++;
+      timerRef.current = setTimeout(runStep, pipeline[current - 1].duration);
+    };
+    runStep();
+  }, []);
+
+  useEffect(() => () => clearTimeout(timerRef.current), []);
+
+  return (
+    <Section id="simulator" dark={false} style={{ background: `linear-gradient(180deg, ${COLORS.navy} 0%, ${COLORS.bg} 100%)` }}>
+      <div ref={ref} style={{ maxWidth: 1000, width: "100%" }}>
+        <div style={{
+          fontFamily: "'JetBrains Mono'", fontSize: 12, color: COLORS.teal,
+          letterSpacing: "0.15em", textTransform: "uppercase", marginBottom: 12,
+        }}>Interactive Demo</div>
+        <h2 style={{
+          fontFamily: "'Outfit'", fontWeight: 800, fontSize: "clamp(26px,3.5vw,42px)",
+          color: COLORS.white, margin: "0 0 8px",
+        }}>Pipeline Simulator</h2>
+        <p style={{
+          fontFamily: "'Outfit'", fontSize: 15, color: COLORS.gray, marginBottom: 32,
+        }}>Watch the intelligent ticket pipeline process a GitHub issue in real time</p>
+
+        {/* Run button */}
+        <button
+          onClick={startSimulation}
+          disabled={running}
+          style={{
+            background: running ? COLORS.grayDark : COLORS.teal,
+            color: running ? COLORS.gray : COLORS.navy,
+            fontFamily: "'Outfit'", fontWeight: 700, fontSize: 16,
+            padding: "14px 36px", borderRadius: 10, border: "none",
+            cursor: running ? "default" : "pointer",
+            marginBottom: 32, transition: "all 0.3s",
+            boxShadow: running ? "none" : `0 4px 24px rgba(45,212,168,0.3)`,
+          }}
+        >
+          {running ? "Running Pipeline..." : "▶  Run Pipeline"}
+        </button>
+
+        {/* Pipeline steps */}
+        <div style={{
+          display: "flex", gap: 4, marginBottom: 24, flexWrap: "wrap", justifyContent: "center",
+        }}>
+          {pipeline.map((p, i) => {
+            const isActive = i === step;
+            const isDone = i < step || (!running && step >= pipeline.length - 1 && i <= pipeline.length - 1);
+            const finalDone = !running && ticketResult && i <= pipeline.length - 1;
+            return (
+              <div key={i} style={{
+                flex: "1 0 120px", maxWidth: 160,
+                background: isActive ? COLORS.teal + "22" : COLORS.card,
+                borderRadius: 8, padding: "12px 10px", textAlign: "center",
+                border: `2px solid ${isActive ? COLORS.teal : finalDone ? COLORS.teal + "55" : COLORS.navyLight}`,
+                transition: "all 0.3s",
+                opacity: inView ? 1 : 0.3,
+              }}>
+                <div style={{
+                  fontSize: 22, marginBottom: 4,
+                  filter: isActive ? "none" : "grayscale(0.5)",
+                  transition: "filter 0.3s",
+                }}>{p.icon}</div>
+                <div style={{
+                  fontFamily: "'Outfit'", fontWeight: 600, fontSize: 11,
+                  color: isActive ? COLORS.teal : finalDone ? COLORS.white : COLORS.gray,
+                }}>{p.name}</div>
+                {isActive && (
+                  <div style={{
+                    width: 16, height: 16, border: `2px solid ${COLORS.teal}`,
+                    borderTop: "2px solid transparent", borderRadius: "50%",
+                    margin: "6px auto 0",
+                    animation: "spin 0.8s linear infinite",
+                  }} />
+                )}
+                {finalDone && !isActive && (
+                  <div style={{ color: COLORS.teal, fontSize: 14, marginTop: 4 }}>&#10003;</div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Log output */}
+        <div style={{
+          background: "#0a0e1a", borderRadius: 10, padding: 20,
+          border: `1px solid ${COLORS.navyLight}`,
+          fontFamily: "'JetBrains Mono'", fontSize: 12, color: COLORS.gray,
+          minHeight: 140, maxHeight: 200, overflowY: "auto",
+        }}>
+          {logs.length === 0 && <span style={{ opacity: 0.5 }}>$ awaiting pipeline execution...</span>}
+          {logs.map((l, i) => (
+            <div key={i} style={{ marginBottom: 6, lineHeight: 1.5 }}>
+              <span style={{ color: COLORS.grayDark }}>[{l.time}]</span>{" "}
+              <span style={{ color: COLORS.teal }}>{l.icon} {l.name}</span>
+              <br />
+              <span style={{ color: COLORS.gray, paddingLeft: 20 }}>{l.log}</span>
+            </div>
+          ))}
+        </div>
+
+        {/* Ticket result */}
+        {ticketResult && (
+          <div style={{
+            background: COLORS.card, borderRadius: 12, padding: 24, marginTop: 20,
+            border: `2px solid ${COLORS.teal}`,
+            animation: "fadeIn 0.5s ease",
+          }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16, flexWrap: "wrap", gap: 8 }}>
+              <div>
+                <span style={{
+                  fontFamily: "'JetBrains Mono'", fontSize: 13, color: COLORS.teal,
+                  background: "rgba(45,212,168,0.15)", padding: "3px 10px", borderRadius: 4,
+                }}>{ticketResult.key}</span>
+                <span style={{
+                  fontFamily: "'Outfit'", fontSize: 16, fontWeight: 600, color: COLORS.white,
+                  marginLeft: 12,
+                }}>{ticketResult.title}</span>
+              </div>
+              <div style={{ display: "flex", gap: 8 }}>
+                <span style={{
+                  fontSize: 11, fontFamily: "'JetBrains Mono'", color: COLORS.gold,
+                  background: "rgba(244,162,97,0.15)", padding: "3px 10px", borderRadius: 4,
+                }}>{ticketResult.priority}</span>
+                <span style={{
+                  fontSize: 11, fontFamily: "'JetBrains Mono'", color: COLORS.teal,
+                  background: "rgba(45,212,168,0.15)", padding: "3px 10px", borderRadius: 4,
+                }}>{ticketResult.type}</span>
+              </div>
+            </div>
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
+              <div>
+                <div style={{ fontFamily: "'Outfit'", fontWeight: 600, fontSize: 13, color: COLORS.teal, marginBottom: 8 }}>
+                  Functional Requirements
+                </div>
+                {ticketResult.fr.map((r, i) => (
+                  <div key={i} style={{
+                    fontFamily: "'Outfit'", fontSize: 13, color: COLORS.gray,
+                    padding: "4px 0", borderBottom: `1px solid ${COLORS.navyLight}`,
+                    lineHeight: 1.5,
+                  }}>&#8226; {r}</div>
+                ))}
+              </div>
+              <div>
+                <div style={{ fontFamily: "'Outfit'", fontWeight: 600, fontSize: 13, color: COLORS.gold, marginBottom: 8 }}>
+                  Non-Functional Requirements
+                </div>
+                {ticketResult.nfr.map((r, i) => (
+                  <div key={i} style={{
+                    fontFamily: "'Outfit'", fontSize: 13, color: COLORS.gray,
+                    padding: "4px 0", borderBottom: `1px solid ${COLORS.navyLight}`,
+                    lineHeight: 1.5,
+                  }}>&#8226; {r}</div>
+                ))}
+              </div>
+            </div>
+            <div style={{
+              marginTop: 16, fontFamily: "'JetBrains Mono'", fontSize: 12,
+              color: COLORS.teal, opacity: 0.8,
+            }}>
+              Total pipeline duration: ~4.8 seconds &middot; 10x faster than manual process
+            </div>
+          </div>
+        )}
+      </div>
+    </Section>
+  );
+}
+
+// ─── Metrics Dashboard ───
+function MetricsSection() {
+  const [ref, inView] = useInView(0.2);
+  const metrics = [
+    { label: "Lead Time", before: "45+ min", after: "< 5 min", improvement: "10x", sublabel: "Argo Workflow duration", color: COLORS.teal },
+    { label: "Process Efficiency", before: "56%", after: "95%+", improvement: "Near-optimal", sublabel: "Value-add / Total time", color: COLORS.teal },
+    { label: "Ticket Quality", before: "~30% rework", after: "< 5% rework", improvement: "6x", sublabel: "Jira ticket reopen rate", color: COLORS.gold },
+    { label: "Throughput", before: "~10/day", after: "Unlimited*", improvement: "Scales", sublabel: "Kubernetes autoscaling", color: COLORS.teal },
+  ];
+
+  const definitions = [
+    { term: "Takt Time", def: "Available time / Customer demand. Sets the pace for sustainable delivery." },
+    { term: "Cycle Time", def: "Time to complete one unit of work. Target: < 5 minutes per ticket." },
+    { term: "Process Efficiency", def: "Value-add time / Total lead time. Higher = less waste." },
+    { term: "First Pass Yield", def: "% of tickets accepted without rework. Quality indicator." },
+  ];
+
+  return (
+    <Section id="metrics">
+      <div ref={ref} style={{ maxWidth: 1000, width: "100%" }}>
+        <div style={{
+          fontFamily: "'JetBrains Mono'", fontSize: 12, color: COLORS.teal,
+          letterSpacing: "0.15em", textTransform: "uppercase", marginBottom: 12,
+        }}>Measuring Success</div>
+        <h2 style={{
+          fontFamily: "'Outfit'", fontWeight: 800, fontSize: "clamp(26px,3.5vw,42px)",
+          color: COLORS.white, margin: "0 0 32px",
+        }}>Key Metrics for Cycle Time and Quality</h2>
+
+        <div style={{
+          display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+          gap: 16, marginBottom: 40,
+        }}>
+          {metrics.map((m, i) => (
+            <div key={m.label} style={{
+              background: COLORS.card, borderRadius: 12, padding: 24,
+              border: `1px solid ${COLORS.navyLight}`,
+              opacity: inView ? 1 : 0,
+              transform: inView ? "translateY(0)" : "translateY(20px)",
+              transition: `all 0.5s ease ${i * 0.1}s`,
+            }}>
+              <div style={{ fontFamily: "'Outfit'", fontWeight: 600, fontSize: 16, color: COLORS.white, marginBottom: 16 }}>{m.label}</div>
+              <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 8 }}>
+                <div>
+                  <div style={{ fontFamily: "'JetBrains Mono'", fontSize: 11, color: COLORS.gray }}>Before</div>
+                  <div style={{ fontFamily: "'JetBrains Mono'", fontSize: 16, color: COLORS.red, fontWeight: 600 }}>{m.before}</div>
+                </div>
+                <div style={{ textAlign: "right" }}>
+                  <div style={{ fontFamily: "'JetBrains Mono'", fontSize: 11, color: COLORS.gray }}>After</div>
+                  <div style={{ fontFamily: "'JetBrains Mono'", fontSize: 16, color: COLORS.teal, fontWeight: 600 }}>{m.after}</div>
+                </div>
+              </div>
+              {/* Progress bar */}
+              <div style={{ height: 6, background: COLORS.navyLight, borderRadius: 3, overflow: "hidden", marginBottom: 12 }}>
+                <div style={{
+                  height: "100%", background: `linear-gradient(90deg, ${COLORS.red}, ${m.color})`,
+                  width: inView ? "100%" : "0%",
+                  borderRadius: 3,
+                  transition: `width 1.2s ease ${0.3 + i * 0.15}s`,
+                }} />
+              </div>
+              <div style={{
+                fontFamily: "'Outfit'", fontWeight: 700, fontSize: 14,
+                color: COLORS.navy, background: m.color,
+                display: "inline-block", padding: "4px 14px", borderRadius: 6,
+              }}>{m.improvement}{m.improvement !== "Near-optimal" && m.improvement !== "Scales" ? " faster" : ""}</div>
+              <div style={{ fontFamily: "'JetBrains Mono'", fontSize: 11, color: COLORS.grayDark, marginTop: 8 }}>{m.sublabel}</div>
+            </div>
+          ))}
+        </div>
+
+        {/* Definitions */}
+        <div style={{
+          background: COLORS.card, borderRadius: 12, padding: 24,
+          border: `1px solid ${COLORS.navyLight}`,
+        }}>
+          <div style={{
+            fontFamily: "'Outfit'", fontWeight: 600, fontSize: 16, color: COLORS.white,
+            marginBottom: 16,
+          }}>Value Stream Metrics Explained</div>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 16 }}>
+            {definitions.map(d => (
+              <div key={d.term}>
+                <div style={{ fontFamily: "'Outfit'", fontWeight: 600, fontSize: 13, color: COLORS.teal }}>{d.term}</div>
+                <div style={{ fontFamily: "'Outfit'", fontSize: 13, color: COLORS.gray, lineHeight: 1.5, marginTop: 4 }}>{d.def}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </Section>
+  );
+}
+
+// ─── Main App ───
+export default function App() {
+  const [active, setActive] = useState("hero");
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const sections = ["hero", "problem", "vsm", "architecture", "simulator", "metrics"];
+      for (const id of [...sections].reverse()) {
+        const el = document.getElementById(id);
+        if (el && el.getBoundingClientRect().top <= 200) {
+          setActive(id);
+          break;
+        }
+      }
+    };
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  return (
+    <div style={{
+      fontFamily: "'Outfit', sans-serif", background: COLORS.bg,
+      minHeight: "100vh", color: COLORS.white,
+    }}>
+      <style>{fonts}{`
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        html { scroll-behavior: smooth; }
+        ::-webkit-scrollbar { width: 6px; }
+        ::-webkit-scrollbar-track { background: ${COLORS.bg}; }
+        ::-webkit-scrollbar-thumb { background: ${COLORS.navyLight}; border-radius: 3px; }
+        @keyframes spin { to { transform: rotate(360deg); } }
+        @keyframes fadeIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
+      `}</style>
+      <Nav active={active} />
+      <Hero />
+      <ProblemSection />
+      <VSMSection />
+      <ArchitectureSection />
+      <SimulatorSection />
+      <MetricsSection />
+      {/* Footer */}
+      <footer style={{
+        textAlign: "center", padding: "40px 24px", background: COLORS.bg,
+        borderTop: `1px solid ${COLORS.navyLight}`,
+      }}>
+        <div style={{ fontFamily: "'Outfit'", fontWeight: 600, fontSize: 18, color: COLORS.white, marginBottom: 8 }}>
+          Thank You
+        </div>
+        <div style={{ fontFamily: "'JetBrains Mono'", fontSize: 12, color: COLORS.gray }}>
+          Gonzalo Vazquez &middot; KCD Toronto 2026 &middot; gonzalovazquez.ca
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/ui/src/main.jsx
+++ b/ui/src/main.jsx
@@ -1,0 +1,9 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App.jsx";
+
+createRoot(document.getElementById("root")).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  base: "/ai-ticketing-pipeline/",
+});


### PR DESCRIPTION
Set up the existing KCD Toronto presentation component as a buildable Vite + React project under ui/, with a GitHub Actions workflow that auto-deploys to GitHub Pages on pushes to main.